### PR TITLE
Ensure that public subnets are deployed to different availability zones

### DIFF
--- a/aws/terraform/modules/vpc/vpc.tf
+++ b/aws/terraform/modules/vpc/vpc.tf
@@ -23,6 +23,7 @@ resource "aws_subnet" "public" {
   count = length(local.public_subnets)
   cidr_block = local.public_subnets[count.index]
   vpc_id = aws_vpc.this.id
+  availability_zone= "${data.aws_availability_zones.available.names[count.index]}"
   map_public_ip_on_launch = true
 
   tags = {


### PR DESCRIPTION
This PR modifies the VPC terraform module to ensure that public subnets are deployed to different availability zones for the EKS