### PR TITLE
Update sealed-secrets Argo CD application definition

### DIFF
--- a/aws/argocd/applications/sealed-secrets.yaml
+++ b/aws/argocd/applications/sealed-secrets.yaml
@@ -1,26 +1,26 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: metrics-server
+  name: sealed-secrets
   namespace: argocd
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:
   project: tooling
   sources:
-  - chart: metrics-server
-    repoURL:  https://kubernetes-sigs.github.io/metrics-server/
-    targetRevision: 3.11.0
+  - chart: sealed-secrets
+    repoURL:  https://bitnami-labs.github.io/sealed-secrets
+    targetRevision: 2.13.0
     helm:
       valueFiles:
-      - $values/aws/charts/metrics-server/values.yaml
+      - $values/aws/charts/sealed-secrets/values.yaml
   - repoURL: 'https://github.com/tbenedek92/platform-demo.git'
     targetRevision: main
     ref: values
 
   destination:
     server: "https://kubernetes.default.svc"
-    namespace: metrics-server
+    namespace: kube-system
   syncPolicy:
     automated:
       prune: true

--- a/aws/argocd/projects/tooling.yaml
+++ b/aws/argocd/projects/tooling.yaml
@@ -16,4 +16,5 @@ spec:
   - https://kubernetes.github.io/ingress-nginx
   - https://kubernetes-sigs.github.io/metrics-server/
   - https://charts.crossplane.io/stable
+  - https://bitnami-labs.github.io/sealed-secrets
 status: {}


### PR DESCRIPTION
In the previous commit I did not saved the modifications for the file, so it was basically duplicating metrics-server. This PR fixes it