### PR TITLE
Pipeline fixes

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -112,4 +112,4 @@ jobs:
             kubectl apply -f aws/argocd/applications
 
     - name: Deploy sealed-secrets TLS secret
-      run: kubectl create secret tls sealed-secrets-key --cert=<(echo ${{ secrets.SEALED_SECRET_CRT }} | base64 -d) --key=<(echo ${{ secrets.SEALED_SECRET_KEY }} | base64 -d) -n kube-system
+      run: kubectl create secret tls sealed-secrets-key --cert=<(echo ${{ secrets.SEALED_SECRET_CRT }} | base64 -d) --key=<(echo ${{ secrets.SEALED_SECRET_KEY }} | base64 -d) -n kube-system -o yaml | kubectl apply -f -

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -103,12 +103,6 @@ jobs:
     - name: Enable prefix delegation
       run: kubectl set env daemonset aws-node -n kube-system ENABLE_PREFIX_DELEGATION=true
 
-    - name: helm repo add ingress-nginx 
-      run: |
-            helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx && \
-            helm repo add argo https://argoproj.github.io/argo-helm && \
-            helm repo update
-
     - name: Deploy ArgoCD
       run: helm upgrade --install argocd -n argocd argo/argo-cd -f aws/charts/argocd/values.yaml --create-namespace
 

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -118,4 +118,4 @@ jobs:
             kubectl apply -f aws/argocd/applications
 
     - name: Deploy sealed-secrets TLS secret
-      run: kubectl create secret tls sealed-secrets-key --cert=<(echo ${{ secrets.SEALED_SECRET_CRT }} | base64 -d) --key=<(echo ${{ secrets.SEALED_SECRET_KEY }} | base64 -d) -n kube-system -o yaml --dry-run client | kubectl apply -f -
+      run: kubectl create secret tls sealed-secrets-key --cert=<(echo ${{ secrets.SEALED_SECRET_CRT }} | base64 -d) --key=<(echo ${{ secrets.SEALED_SECRET_KEY }} | base64 -d) -n kube-system -o yaml --dry-run=client | kubectl apply -f -

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -103,6 +103,12 @@ jobs:
     - name: Enable prefix delegation
       run: kubectl set env daemonset aws-node -n kube-system ENABLE_PREFIX_DELEGATION=true
 
+    - name: helm repo add argo
+      run: |
+            helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx && \
+            helm repo add argo https://argoproj.github.io/argo-helm && \
+            helm repo update
+
     - name: Deploy ArgoCD
       run: helm upgrade --install argocd -n argocd argo/argo-cd -f aws/charts/argocd/values.yaml --create-namespace
 

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -118,4 +118,4 @@ jobs:
             kubectl apply -f aws/argocd/applications
 
     - name: Deploy sealed-secrets TLS secret
-      run: kubectl create secret tls sealed-secrets-key --cert=<(echo ${{ secrets.SEALED_SECRET_CRT }} | base64 -d) --key=<(echo ${{ secrets.SEALED_SECRET_KEY }} | base64 -d) -n kube-system -o yaml | kubectl apply -f -
+      run: kubectl create secret tls sealed-secrets-key --cert=<(echo ${{ secrets.SEALED_SECRET_CRT }} | base64 -d) --key=<(echo ${{ secrets.SEALED_SECRET_KEY }} | base64 -d) -n kube-system -o yaml --dry-run client | kubectl apply -f -


### PR DESCRIPTION
Fixing `configure-cluster` pipeline job:
- rename `helm repo add argo` step
- fix pipeline failing when secret already existed in cluster